### PR TITLE
Supporting minSdkVersion 23+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha10'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 
@@ -49,7 +49,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/android/src/main/java/com/contentful/rich/android/renderer/chars/EmbeddedLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/chars/EmbeddedLinkRenderer.java
@@ -154,7 +154,7 @@ public class EmbeddedLinkRenderer extends BlockRenderer {
 
       if (title != null) {
         builder.insert(0, title);
-        builder.setSpan(new ForegroundColorSpan(Color.argb(1.0f, 1.0f, 0.5f, 1.0f)), 0, title.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        builder.setSpan(new ForegroundColorSpan(Color.argb(255, 255, 255, 255)), 0, title.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
       }
     } else if (data instanceof CDAAsset) {
       final CDAAsset asset = (CDAAsset) data;

--- a/android/src/main/java/com/contentful/rich/android/renderer/chars/ListRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/chars/ListRenderer.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -144,10 +143,15 @@ public class ListRenderer extends BlockRenderer {
    * @return the number of lists of the supported type.
    */
   private long getListOfTypeCount(@Nonnull AndroidContext context, CDARichList list) {
-    return (context.getPath().stream().filter(new Predicate<CDARichNode>() {
-      @Override public boolean test(CDARichNode x) {
-        return x instanceof CDARichList && ((CDARichList) x).getDecoration().equals(list.getDecoration());
+    if (context.getPath() == null) {
+      return 0;
+    }
+    int count = 0;
+    for (CDARichNode node: context.getPath()) {
+      if (node instanceof CDARichList && ((CDARichList) node).getDecoration().equals(list.getDecoration())) {
+        count++;
       }
-    }).count() - 1);
+    }
+    return count;
   }
 }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/ListRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/ListRenderer.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -109,12 +108,24 @@ public class ListRenderer extends BlockRenderer {
     decoration.setText(currentDecorator.decorate(childIndex + 1));
   }
 
+  /**
+   * Count lists on the path.
+   *
+   * @param context where is the path stored in? The context!
+   * @param list    the list to be listed.
+   * @return the number of lists of the supported type.
+   */
   private long getListOfTypeCount(@Nonnull AndroidContext context, CDARichList list) {
-    return (context.getPath().stream().filter(new Predicate<CDARichNode>() {
-      @Override public boolean test(CDARichNode x) {
-        return x instanceof CDARichList && ((CDARichList) x).getDecoration().equals(list.getDecoration());
+    if (context.getPath() == null) {
+      return 0;
+    }
+    int count = 0;
+    for (CDARichNode node: context.getPath()) {
+      if (node instanceof CDARichList && ((CDARichList) node).getDecoration().equals(list.getDecoration())) {
+        count++;
       }
-    }).count() - 1);
+    }
+    return count;
   }
 
 }

--- a/android_sample/build.gradle
+++ b/android_sample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha10'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: "maven"
 
 
 allprojects {
-    group = "com.github.drezzzik.rich"
+    group = "com.github.drezzzik"
 
     version = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: "maven"
 
 
 allprojects {
-    group = "com.github.contentful.rich"
+    group = "com.github.drezzzik.rich"
 
     version = '1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     sourceCompatibility = 1.8 // java 8
     targetCompatibility = 1.8
 
-    ext.contentful_version = "v10.2.1"
+    ext.contentful_version = "v10.4.1"
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: "maven"
 
 
 allprojects {
-    group = "com.github.drezzzik"
+    group = "com.github.contentful.rich"
 
     version = '1.0.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 15 10:53:35 CEST 2019
+#Wed Aug 28 10:20:17 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-rc-2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
In order to support minSdkVersion < 26
- Java 8 API usage is removed
- Android API 26 usage is removed

Official [documentation](https://developer.android.com/distribute/best-practices/develop/target-sdk) states that targetSdkVersion should be increased not the minSdkVersion.

That way library will be reachable for additional 50% Android devices (while currently works only on 39%), as it is current state of [distribution](https://developer.android.com/about/dashboards).