### PR TITLE
consistent terminology [library-1766]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Contentful Rich Text Rendering SDK for Java
-===========================================
+Contentful Rich Text Rendering Library for Java
+===============================================
 
-> Java SDK for [Rich Text API](https://www.contentful.com/developers/docs/tutorials/general/rich-text-field-type-alpha/) . It helps in easily rendering rich text stored in Contentful using Java.
+> Java Library for [Rich Text API](https://www.contentful.com/developers/docs/tutorials/general/rich-text-field-type-alpha/) . It helps in easily rendering rich text stored in Contentful using Java.
 
 
 What is Contentful?
@@ -24,7 +24,7 @@ What is Contentful?
 Core Features
 =============
 
-Take rich text elements from the [BaseSdk](https://github.com/contentful/contentful.java) and render them in a representation easy to use and understand and even easier to use in own projects, due to these submodules:
+Take rich text elements from the [base library](https://github.com/contentful/contentful.java) and render them in a representation easy to use and understand and even easier to use in own projects, due to these submodules:
 
 Html
 ====

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Contentful Rich Text Rendering Library for Java
 ===============================================
 
-> Java Library for [Rich Text API](https://www.contentful.com/developers/docs/tutorials/general/rich-text-field-type-alpha/) . It helps in easily rendering rich text stored in Contentful using Java.
+> Java library for [Rich Text API](https://www.contentful.com/developers/docs/tutorials/general/rich-text-field-type-alpha/) . It helps in easily rendering rich text stored in Contentful using Java.
 
 
 What is Contentful?


### PR DESCRIPTION
For all public CMA and CDA projects, we will replace the terminology `SDK` with `library`