### PR TITLE
Fix groupId of Maven dependency

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -45,7 +45,7 @@ same can be achieved by adding Maven dependencies like so:
 	    <version>10.5.3</version>
 	</dependency>
 	<dependency>
-	    <groupId>com.github.contentful.rich</groupId>
+	    <groupId>com.github.contentful.rich-text-renderer-java</groupId>
 	    <artifactId>html</artifactId>
 	    <version>1.3.0</version>
 	</dependency>


### PR DESCRIPTION
The groupId for the Maven dependency in the README file was wrong.