### PR TITLE
Fix bad downcast in HtmlRendererProvider + html dependency bump

### DIFF
--- a/html/build.gradle
+++ b/html/build.gradle
@@ -38,9 +38,9 @@ dependencies {
     api (project(":core"))
     api "com.contentful.java:java-sdk:${project.contentful_version}"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-text:1.10.0'
     testImplementation 'com.google.truth:truth:0.42'
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/html/src/main/java/com/contentful/rich/html/HtmlRendererProvider.java
+++ b/html/src/main/java/com/contentful/rich/html/HtmlRendererProvider.java
@@ -22,9 +22,9 @@ import com.contentful.rich.html.renderer.DynamicTagRenderer;
 import com.contentful.rich.html.renderer.TagRenderer;
 import com.contentful.rich.html.renderer.TagWithArgumentsRenderer;
 import com.contentful.rich.html.renderer.TextRenderer;
-import com.google.gson.internal.LinkedTreeMap;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 import static com.contentful.rich.html.renderer.TagWithArgumentsRenderer.mapifyArguments;
 
@@ -61,11 +61,11 @@ class HtmlRendererProvider {
             (node) -> mapifyArguments("href", (String) ((CDARichHyperLink) node).getData()))
     );
     processor.addRenderer(
-            (context, node) -> node instanceof CDARichHyperLink && ((CDARichHyperLink) node).getData() instanceof LinkedTreeMap,
+            (context, node) -> node instanceof CDARichHyperLink && ((CDARichHyperLink) node).getData() instanceof Map,
             new TagWithArgumentsRenderer(
                     processor,
                     "a",
-                    (node) -> mapifyArguments("href", (String) ((LinkedTreeMap<?, ?>) ((CDARichHyperLink) node).getData()).get("uri")))
+                    (node) -> mapifyArguments("href", (String) ((Map<?, ?>) ((CDARichHyperLink) node).getData()).get("uri")))
     );
     processor.addRenderer(
         (context, node) -> node instanceof CDARichQuote,

--- a/html/src/test/java/LinksTest.java
+++ b/html/src/test/java/LinksTest.java
@@ -6,6 +6,8 @@ import com.contentful.rich.html.HtmlProcessor;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -26,6 +28,24 @@ public class LinksTest {
         "<a href=\"https://contentful.com\">\n" +
         "  Some link text&lt;br/&gt;\n" +
         "</a>\n");
+  }
+
+  @Test
+  public void renderLinkWithUriTest() {
+    final HtmlProcessor processor = new HtmlProcessor();
+    final HtmlContext context = new HtmlContext();
+
+    final Map<String, Object> linkProps = new HashMap<>();
+    linkProps.put("uri", "https://contentful.com");
+    final CDARichHyperLink link = new CDARichHyperLink(linkProps);
+    link.getContent().add(new CDARichText("Some link text<br/>", new ArrayList<>()));
+
+    final String result = processor.process(context, link);
+
+    assertThat(result).isEqualTo("" +
+            "<a href=\"https://contentful.com\">\n" +
+            "  Some link text&lt;br/&gt;\n" +
+            "</a>\n");
   }
 
   @Test


### PR DESCRIPTION
**Don't downcast to GSON classes in HtmlRendererProvider**
Downcasting `data` to `LinkedTreeMap` means that a `CDARichHyperLink` constructed in any other way than parsing with GSON will silently just render as `null`. It also seems unnecessarily brittle with respect to changes in GSON. Fix by just downcasting to `Map` (which is all we need anyway).

**Update dependencies in html**
`commons-text:1.9` is affected by [CVE-2022-42889](https://github.com/advisories/GHSA-599f-7c49-w659). From what I can see the usage in html is not affected, but we might as well upgrade.

`core` and `android` already depended on `junit:4.13.2` so upgrading in `html` just brings it in line with the other modules.