### PR TITLE
fix: trim uri whitespace [DX-892]

### DIFF
--- a/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
@@ -66,7 +66,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     if (data instanceof String) {
         uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
+        String temp = (String) ((Map<?, ?>) data).get("uri");
+        if (temp == null) return builder;
+        uri = temp.trim();
     } else {
         return builder; // Return unchanged if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
@@ -64,9 +64,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     final String uri;
     
     if (data instanceof String) {
-        uri = (String) data;
+        uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = (String) ((Map<?, ?>) data).get("uri");
+        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
     } else {
         return builder; // Return unchanged if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
@@ -110,7 +110,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     if (data instanceof String) {
         uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
+        String temp = (String) ((Map<?, ?>) data).get("uri");
+        if (temp == null) return;
+        uri = temp.trim();
     } else {
         return; // Don't handle click if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
@@ -108,9 +108,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     final String uri;
 
     if (data instanceof String) {
-        uri = (String) data;
+        uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = (String) ((Map<?, ?>) data).get("uri");
+        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
     } else {
         return; // Don't handle click if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
@@ -147,7 +147,9 @@ public class QuoteRenderer extends BlockRenderer {
       content.append(textContent);
     } else if (node instanceof CDARichHyperLink) {
       final CDARichHyperLink hyperlink = (CDARichHyperLink) node;
-      final String uri = ((String) hyperlink.getData()).trim();
+      final Object data = hyperlink.getData();
+      if (!(data instanceof String)) return;
+      final String uri = ((String) data).trim();
       
       // Process hyperlink content
       for (final CDARichNode hyperlinkContent : hyperlink.getContent()) {

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
@@ -147,7 +147,7 @@ public class QuoteRenderer extends BlockRenderer {
       content.append(textContent);
     } else if (node instanceof CDARichHyperLink) {
       final CDARichHyperLink hyperlink = (CDARichHyperLink) node;
-      final String uri = (String) hyperlink.getData();
+      final String uri = ((String) hyperlink.getData()).trim();
       
       // Process hyperlink content
       for (final CDARichNode hyperlinkContent : hyperlink.getContent()) {

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
@@ -36,6 +36,7 @@ import com.contentful.rich.android.R;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Map;
 
 public class QuoteRenderer extends BlockRenderer {
   public QuoteRenderer(@Nonnull AndroidProcessor<View> processor) {
@@ -148,8 +149,16 @@ public class QuoteRenderer extends BlockRenderer {
     } else if (node instanceof CDARichHyperLink) {
       final CDARichHyperLink hyperlink = (CDARichHyperLink) node;
       final Object data = hyperlink.getData();
-      if (!(data instanceof String)) return;
-      final String uri = ((String) data).trim();
+      final String uri;
+      if (data instanceof String) {
+        uri = ((String) data).trim();
+      } else if (data instanceof Map) {
+        final Object uriObj = ((Map<?, ?>) data).get("uri");
+        if (!(uriObj instanceof String)) return;
+        uri = ((String) uriObj).trim();
+      } else {
+        return;
+      }
       
       // Process hyperlink content
       for (final CDARichNode hyperlinkContent : hyperlink.getContent()) {

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
@@ -191,9 +191,9 @@ public class TableRenderer extends BlockRenderer {
                                         if (data instanceof String) {
                                             uri = ((String) data).trim();
                                         } else if (data instanceof Map) {
-                                            String temp = (String) ((Map<?, ?>) data).get("uri");
-                                            if (temp == null) continue;
-                                            uri = temp.trim();
+                                            final Object uriObj = ((Map<?, ?>) data).get("uri");
+                                            if (!(uriObj instanceof String)) continue;
+                                            uri = ((String) uriObj).trim();
                                         } else {
                                             continue;
                                         }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
@@ -191,7 +191,9 @@ public class TableRenderer extends BlockRenderer {
                                         if (data instanceof String) {
                                             uri = ((String) data).trim();
                                         } else if (data instanceof Map) {
-                                            uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
+                                            String temp = (String) ((Map<?, ?>) data).get("uri");
+                                            if (temp == null) continue;
+                                            uri = temp.trim();
                                         } else {
                                             continue;
                                         }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
@@ -189,9 +189,9 @@ public class TableRenderer extends BlockRenderer {
                                         final String uri;
                                         
                                         if (data instanceof String) {
-                                            uri = (String) data;
+                                            uri = ((String) data).trim();
                                         } else if (data instanceof Map) {
-                                            uri = (String) ((Map<?, ?>) data).get("uri");
+                                            uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
                                         } else {
                                             continue;
                                         }

--- a/android/src/test/java/chars/LinkTest.java
+++ b/android/src/test/java/chars/LinkTest.java
@@ -74,6 +74,21 @@ public class LinkTest {
   }
 
   @Test
+  public void hyperlinkWithLeadingWhitespaceTrimsUrl() {
+    final AndroidProcessor<CharSequence> processor = AndroidProcessor.creatingCharSequences();
+    final AndroidContext context = new AndroidContext(activity);
+
+    final CDARichHyperLink link = new CDARichHyperLink("  https://contentful.com");
+    link.getContent().add(new CDARichText("Some link text", new ArrayList<>()));
+
+    final CharSequence result = processor.process(context, link);
+
+    assertThat(result).isInstanceOf(Spannable.class);
+    final URLSpan span = (URLSpan) ((Spannable) result).getSpans(0, result.length(), URLSpan.class)[0];
+    assertThat(span.getURL()).isEqualTo("https://contentful.com");
+  }
+
+  @Test
   public void createEmbeddedLink() {
     final AndroidProcessor<CharSequence> processor = AndroidProcessor.creatingCharSequences();
     final AndroidContext context = new AndroidContext(activity);

--- a/android/src/test/java/views/LinkTest.java
+++ b/android/src/test/java/views/LinkTest.java
@@ -1,6 +1,7 @@
 package views;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -10,12 +11,14 @@ import com.contentful.java.cda.rich.CDARichText;
 import com.contentful.rich.android.AndroidContext;
 import com.contentful.rich.android.AndroidProcessor;
 import com.contentful.rich.android.R;
+import com.contentful.rich.android.renderer.views.HyperLinkRenderer;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
 
 import java.util.ArrayList;
 
@@ -90,6 +93,13 @@ public class LinkTest {
     content.findViewsWithText(views, "Some link text", View.FIND_VIEWS_WITH_TEXT);
     assertThat(views).hasSize(1);
     assertThat(views.get(0)).isInstanceOf(TextView.class);
+
+    final HyperLinkRenderer renderer = new HyperLinkRenderer(processor);
+    renderer.onClick(context, link);
+
+    final Intent startedIntent = Shadows.shadowOf(activity).getNextStartedActivity();
+    assertThat(startedIntent).isNotNull();
+    assertThat(startedIntent.getData().toString()).isEqualTo("https://contentful.com");
   }
 
   @Test

--- a/android/src/test/java/views/LinkTest.java
+++ b/android/src/test/java/views/LinkTest.java
@@ -73,6 +73,26 @@ public class LinkTest {
   }
 
   @Test
+  public void hyperlinkWithLeadingWhitespaceTrimsUrl() {
+    final AndroidProcessor<View> processor = AndroidProcessor.creatingNativeViews();
+    final AndroidContext context = new AndroidContext(activity);
+
+    final CDARichHyperLink link = new CDARichHyperLink("  https://contentful.com");
+    link.getContent().add(new CDARichText("Some link text", new ArrayList<>()));
+
+    final View result = processor.process(context, link);
+
+    assertThat(result).isNotNull();
+    final View content = result.findViewById(R.id.rich_content);
+    assertThat(content).isNotNull();
+
+    ArrayList<View> views = new ArrayList<>();
+    content.findViewsWithText(views, "Some link text", View.FIND_VIEWS_WITH_TEXT);
+    assertThat(views).hasSize(1);
+    assertThat(views.get(0)).isInstanceOf(TextView.class);
+  }
+
+  @Test
   public void createEmbeddedLink() {
     final AndroidProcessor<View> processor = AndroidProcessor.creatingNativeViews();
     final AndroidContext context = new AndroidContext(activity);


### PR DESCRIPTION
### Problem

When a URL is authored with leading (or trailing) whitespace in the Contentful rich text editor and rendered using the Android SDK, the link silently breaks. `Uri.parse()` and `URLSpan` cannot handle whitespace-prefixed strings, so clicking the link either does nothing or throws an `ActivityNotFoundException`. This was reported against v2.3.2.

### Changes

Four Android renderers were each passing the raw URI string directly to `Uri.parse()` or `URLSpan()` without sanitization. A `.trim()` call has been added at the point the URI is extracted from the node's data in each:

- `android/renderer/chars/HyperLinkRenderer` — `URLSpan` path
- `android/renderer/views/HyperLinkRenderer` — `Uri.parse` / `Intent.ACTION_VIEW` path
- `android/renderer/views/TableRenderer` — inline hyperlink handler inside table cells
- `android/renderer/views/QuoteRenderer` — inline hyperlink handler inside quote blocks

### Tests

Regression tests added to both `chars/LinkTest` and `views/LinkTest` that create a `CDARichHyperLink` with a leading-whitespace URL (`"  https://contentful.com"`) and assert the resolved URL is correctly trimmed.

### Notes

- `.trim()` removes both leading and trailing whitespace. Whitespace is never valid in a URL, so this is correct behavior in both directions.
- `QuoteRenderer` only handles `String`-typed URI data (not `Map`). This is a pre-existing limitation unrelated to this fix.
- The `html` module has the same latent issue but is out of scope for this change. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request fixes a bug where hyperlinks in Contentful rich text authored with leading or trailing whitespace would silently fail or throw exceptions on Android by trimming whitespace from URI strings in multiple renderers.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds .trim() to URI extraction in HyperLinkRenderer (chars package) to sanitize URLs before creating URLSpan.</li>

<li>Adds .trim() to URI extraction in HyperLinkRenderer (views package) to sanitize URLs before parsing with Uri.parse() for Intent.ACTION_VIEW.</li>

<li>Adds .trim() to URI extraction in TableRenderer for inline hyperlinks within table cells.</li>

<li>Adds .trim() to URI extraction in QuoteRenderer for inline hyperlinks within quote blocks.</li>

<li>Adds regression tests in chars/LinkTest and views/LinkTest to verify trimming of leading whitespace in URLs.</li>

</ul>
</details>

</div>