### PR TITLE
Release/2.3.4

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -23,8 +23,8 @@ allprojects {
 dependencies {
   // …
   implementation 'com.contentful.java:java-sdk:10.5.18'
-  implementation 'com.github.contentful.rich-text-renderer-java:android:2.3.3'
-  implementation 'com.github.contentful.rich-text-renderer-java:core:2.3.3'
+  implementation 'com.github.contentful.rich-text-renderer-java:android:2.3.4'
+  implementation 'com.github.contentful.rich-text-renderer-java:core:2.3.4'
 }
 ```
 
@@ -48,12 +48,12 @@ same can be achieved by adding Maven dependencies like so:
    <dependency>
        <groupId>com.github.contentful.rich-text-renderer-java</groupId>
        <artifactId>core</artifactId>
-       <version>2.3.3</version>
+       <version>2.3.4</version>
    </dependency>
    <dependency>
        <groupId>com.github.contentful.rich-text-renderer-java</groupId>
        <artifactId>android</artifactId>
-       <version>2.3.3</version>
+       <version>2.3.4</version>
    </dependency>
 ```
 

--- a/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
@@ -66,7 +66,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     if (data instanceof String) {
         uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
+        String temp = (String) ((Map<?, ?>) data).get("uri");
+        if (temp == null) return builder;
+        uri = temp.trim();
     } else {
         return builder; // Return unchanged if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/chars/HyperLinkRenderer.java
@@ -64,9 +64,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     final String uri;
     
     if (data instanceof String) {
-        uri = (String) data;
+        uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = (String) ((Map<?, ?>) data).get("uri");
+        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
     } else {
         return builder; // Return unchanged if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
@@ -110,7 +110,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     if (data instanceof String) {
         uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
+        String temp = (String) ((Map<?, ?>) data).get("uri");
+        if (temp == null) return;
+        uri = temp.trim();
     } else {
         return; // Don't handle click if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/HyperLinkRenderer.java
@@ -108,9 +108,9 @@ public class HyperLinkRenderer extends BlockRenderer {
     final String uri;
 
     if (data instanceof String) {
-        uri = (String) data;
+        uri = ((String) data).trim();
     } else if (data instanceof Map) {
-        uri = (String) ((Map<?, ?>) data).get("uri");
+        uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
     } else {
         return; // Don't handle click if data is neither String nor Map
     }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
@@ -147,7 +147,9 @@ public class QuoteRenderer extends BlockRenderer {
       content.append(textContent);
     } else if (node instanceof CDARichHyperLink) {
       final CDARichHyperLink hyperlink = (CDARichHyperLink) node;
-      final String uri = ((String) hyperlink.getData()).trim();
+      final Object data = hyperlink.getData();
+      if (!(data instanceof String)) return;
+      final String uri = ((String) data).trim();
       
       // Process hyperlink content
       for (final CDARichNode hyperlinkContent : hyperlink.getContent()) {

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
@@ -147,7 +147,7 @@ public class QuoteRenderer extends BlockRenderer {
       content.append(textContent);
     } else if (node instanceof CDARichHyperLink) {
       final CDARichHyperLink hyperlink = (CDARichHyperLink) node;
-      final String uri = (String) hyperlink.getData();
+      final String uri = ((String) hyperlink.getData()).trim();
       
       // Process hyperlink content
       for (final CDARichNode hyperlinkContent : hyperlink.getContent()) {

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/QuoteRenderer.java
@@ -36,6 +36,7 @@ import com.contentful.rich.android.R;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Map;
 
 public class QuoteRenderer extends BlockRenderer {
   public QuoteRenderer(@Nonnull AndroidProcessor<View> processor) {
@@ -148,8 +149,16 @@ public class QuoteRenderer extends BlockRenderer {
     } else if (node instanceof CDARichHyperLink) {
       final CDARichHyperLink hyperlink = (CDARichHyperLink) node;
       final Object data = hyperlink.getData();
-      if (!(data instanceof String)) return;
-      final String uri = ((String) data).trim();
+      final String uri;
+      if (data instanceof String) {
+        uri = ((String) data).trim();
+      } else if (data instanceof Map) {
+        final Object uriObj = ((Map<?, ?>) data).get("uri");
+        if (!(uriObj instanceof String)) return;
+        uri = ((String) uriObj).trim();
+      } else {
+        return;
+      }
       
       // Process hyperlink content
       for (final CDARichNode hyperlinkContent : hyperlink.getContent()) {

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
@@ -191,9 +191,9 @@ public class TableRenderer extends BlockRenderer {
                                         if (data instanceof String) {
                                             uri = ((String) data).trim();
                                         } else if (data instanceof Map) {
-                                            String temp = (String) ((Map<?, ?>) data).get("uri");
-                                            if (temp == null) continue;
-                                            uri = temp.trim();
+                                            final Object uriObj = ((Map<?, ?>) data).get("uri");
+                                            if (!(uriObj instanceof String)) continue;
+                                            uri = ((String) uriObj).trim();
                                         } else {
                                             continue;
                                         }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
@@ -191,7 +191,9 @@ public class TableRenderer extends BlockRenderer {
                                         if (data instanceof String) {
                                             uri = ((String) data).trim();
                                         } else if (data instanceof Map) {
-                                            uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
+                                            String temp = (String) ((Map<?, ?>) data).get("uri");
+                                            if (temp == null) continue;
+                                            uri = temp.trim();
                                         } else {
                                             continue;
                                         }

--- a/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
+++ b/android/src/main/java/com/contentful/rich/android/renderer/views/TableRenderer.java
@@ -189,9 +189,9 @@ public class TableRenderer extends BlockRenderer {
                                         final String uri;
                                         
                                         if (data instanceof String) {
-                                            uri = (String) data;
+                                            uri = ((String) data).trim();
                                         } else if (data instanceof Map) {
-                                            uri = (String) ((Map<?, ?>) data).get("uri");
+                                            uri = ((String) ((Map<?, ?>) data).get("uri")).trim();
                                         } else {
                                             continue;
                                         }

--- a/android/src/test/java/chars/LinkTest.java
+++ b/android/src/test/java/chars/LinkTest.java
@@ -74,6 +74,21 @@ public class LinkTest {
   }
 
   @Test
+  public void hyperlinkWithLeadingWhitespaceTrimsUrl() {
+    final AndroidProcessor<CharSequence> processor = AndroidProcessor.creatingCharSequences();
+    final AndroidContext context = new AndroidContext(activity);
+
+    final CDARichHyperLink link = new CDARichHyperLink("  https://contentful.com");
+    link.getContent().add(new CDARichText("Some link text", new ArrayList<>()));
+
+    final CharSequence result = processor.process(context, link);
+
+    assertThat(result).isInstanceOf(Spannable.class);
+    final URLSpan span = (URLSpan) ((Spannable) result).getSpans(0, result.length(), URLSpan.class)[0];
+    assertThat(span.getURL()).isEqualTo("https://contentful.com");
+  }
+
+  @Test
   public void createEmbeddedLink() {
     final AndroidProcessor<CharSequence> processor = AndroidProcessor.creatingCharSequences();
     final AndroidContext context = new AndroidContext(activity);

--- a/android/src/test/java/views/LinkTest.java
+++ b/android/src/test/java/views/LinkTest.java
@@ -1,6 +1,7 @@
 package views;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.view.View;
 import android.widget.TextView;
 
@@ -10,12 +11,14 @@ import com.contentful.java.cda.rich.CDARichText;
 import com.contentful.rich.android.AndroidContext;
 import com.contentful.rich.android.AndroidProcessor;
 import com.contentful.rich.android.R;
+import com.contentful.rich.android.renderer.views.HyperLinkRenderer;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
 
 import java.util.ArrayList;
 
@@ -90,6 +93,13 @@ public class LinkTest {
     content.findViewsWithText(views, "Some link text", View.FIND_VIEWS_WITH_TEXT);
     assertThat(views).hasSize(1);
     assertThat(views.get(0)).isInstanceOf(TextView.class);
+
+    final HyperLinkRenderer renderer = new HyperLinkRenderer(processor);
+    renderer.onClick(context, link);
+
+    final Intent startedIntent = Shadows.shadowOf(activity).getNextStartedActivity();
+    assertThat(startedIntent).isNotNull();
+    assertThat(startedIntent.getData().toString()).isEqualTo("https://contentful.com");
   }
 
   @Test

--- a/android/src/test/java/views/LinkTest.java
+++ b/android/src/test/java/views/LinkTest.java
@@ -73,6 +73,26 @@ public class LinkTest {
   }
 
   @Test
+  public void hyperlinkWithLeadingWhitespaceTrimsUrl() {
+    final AndroidProcessor<View> processor = AndroidProcessor.creatingNativeViews();
+    final AndroidContext context = new AndroidContext(activity);
+
+    final CDARichHyperLink link = new CDARichHyperLink("  https://contentful.com");
+    link.getContent().add(new CDARichText("Some link text", new ArrayList<>()));
+
+    final View result = processor.process(context, link);
+
+    assertThat(result).isNotNull();
+    final View content = result.findViewById(R.id.rich_content);
+    assertThat(content).isNotNull();
+
+    ArrayList<View> views = new ArrayList<>();
+    content.findViewsWithText(views, "Some link text", View.FIND_VIEWS_WITH_TEXT);
+    assertThat(views).hasSize(1);
+    assertThat(views.get(0)).isInstanceOf(TextView.class);
+  }
+
+  @Test
   public void createEmbeddedLink() {
     final AndroidProcessor<View> processor = AndroidProcessor.creatingNativeViews();
     final AndroidContext context = new AndroidContext(activity);

--- a/html/README.md
+++ b/html/README.md
@@ -23,7 +23,7 @@ allprojects {
 dependencies {
   // …
   implementation 'com.github.contentful:contentful.java:v10.5.18'
-  implementation 'com.github.contentful.rich-text-renderer-java:html:2.3.1'
+  implementation 'com.github.contentful.rich-text-renderer-java:html:2.3.4'
 }
 ```
 
@@ -47,7 +47,7 @@ same can be achieved by adding Maven dependencies like so:
    <dependency>
         <groupId>com.github.contentful.rich-text-renderer-java</groupId>
         <artifactId>html</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.4</version>
    </dependency>
 ```
 


### PR DESCRIPTION
Resolves this PR as a new release: https://github.com/contentful/rich-text-renderer-java/pull/61 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This release includes bug fixes for hyperlink URI handling in the Android rich text renderer, ensuring URIs are trimmed of whitespace and null-checked to prevent crashes, resolving issues from the referenced pull request.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds .trim() to URIs in hyperlink renderers (HyperLinkRenderer.java files) to remove leading/trailing whitespace</li>

<li>Introduces null checks for URI values in Map data structures to prevent NullPointerExceptions</li>

<li>Updates QuoteRenderer and TableRenderer to handle hyperlinks with improved URI processing</li>

<li>Adds unit tests verifying whitespace trimming in hyperlink URIs for both char and view renderers</li>

</ul>
</details>

</div>