### PR TITLE
fix: bump root version to 2.3.5 for android artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
     group = "com.github.contentful.rich"
-    version = '2.3.3'
+    version = '2.3.4'
     ext.contentful_version = "10.5.18"
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
     group = "com.github.contentful.rich"
-    version = '2.3.4'
+    version = '2.3.5'
     ext.contentful_version = "10.5.18"
 
     repositories {


### PR DESCRIPTION
## Summary

- The `chore: prepare release 2.3.4` commit only updated READMEs and missed bumping `version` in root `build.gradle`
- `android/build.gradle` derives its published version from `project.version` (root), so JitPack built and cached `android:2.3.3` under the `2.3.4` tag
- Since `2.3.4` tag already exists, this fix ships as `2.3.5`
- `core` and `html` hardcode their own versions and are intentionally frozen at `2.3.0` — those are unaffected

## What changed

Single line in `build.gradle`: `version = '2.3.3'` → `'2.3.5'`

## Next steps after merge

- Cut a new `2.3.5` tag and GitHub release pointing at the merge commit — JitPack will detect it and publish the corrected artifact
- Verify `com/github/contentful/rich-text-renderer-java/android/2.3.5/android-2.3.5.pom` contains the correct version

## Related

- Customer report: android:2.3.4 not published / build failures on upgrade from 2.3.3
- ES-192 (original URL whitespace bug this release was meant to fix) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes Android artifact version publishing by bumping the root project version from '2.3.4' to '2.3.5'. The previous 2.3.4 release commit only updated READMEs and documentation but failed to increment the version in `build.gradle`, causing JitPack to cache `android:2.3.3` under the 2.3.4 tag. Since that tag already exists, this fix ships as 2.3.5.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Single-line fix in `build.gradle`: updated `version = '2.3.4'` to `'2.3.5'` in the allprojects block to correct Android artifact publishing</li>

<li>Root cause: 2.3.4 release tag was created without bumping the version, causing JitPack to cache incorrect Android artifact version</li>

<li>The `android` submodule derives its published version from `project.version` (root), so this change propagates to the correct artifact</li>

<li>`core` and `html` modules hardcode their own versions at 2.3.0 and are unaffected</li>

</ul>
</details>

</div>